### PR TITLE
Set dispatcher from Silex app

### DIFF
--- a/src/Saxulum/Console/Provider/ConsoleProvider.php
+++ b/src/Saxulum/Console/Provider/ConsoleProvider.php
@@ -30,6 +30,11 @@ class ConsoleProvider
 
         $container['console'] = $container->share(function () use ($container) {
             $console = new ConsoleApplication($container);
+
+            if (isset($container['dispatcher']) && !is_null($container['dispatcher'])) {
+                $console->setDispatcher($container['dispatcher']);
+            }
+
             foreach ($container['console.commands'] as $command) {
                 $console->add($command);
             }


### PR DESCRIPTION
This proposal sets the default event dispatcher of Silex into the provided `ConsoleApplication`. This allows you to subscribe to the default `ConsoleEvents` that are dispatched inside the Symfony Console Application.

```
$app = require __DIR__.'/../app/app.php';

$app->on(ConsoleEvents::TERMINATE, function () use ($app) {
    // flush queue (for sending emails from command line)
    $app['swiftmailer.spooltransport']
        ->getSpool()
        ->flushQueue($app['swiftmailer.transport']);
});

$app->boot();
$app['console']->run();
```
